### PR TITLE
Version 2.1.3 contains a patch for CVE-2024-43381

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,13 +8,13 @@
 
 ### Security Update
 
-* (Security) CVE-2023-50094 Stored Cross-Site Scripting (XSS) via DNS Record Poisoning reported by @touhidshaikh Advisory https://github.com/yogeshojha/rengine/security/advisories/GHSA-96q4-fj2m-jqf7
+* (Security) CVE-2024-43381 Stored Cross-Site Scripting (XSS) via DNS Record Poisoning reported by @touhidshaikh Advisory https://github.com/yogeshojha/rengine/security/advisories/GHSA-96q4-fj2m-jqf7
 
 ### Bug Fixes
 
 * remove redundant docker environment variables by @jxdv in https://github.com/yogeshojha/rengine/pull/1353
 * fix: reNgine installation issue due to orjson and langchain #1362 by @yogeshojha in https://github.com/yogeshojha/rengine/pull/1363
-* #1364 FIx whois lookup and improve performance by executing various modules of whois lookup to run concurrently by @yogeshojha in https://github.com/yogeshojha/rengine/pull/1368
+* #1364 Fix whois lookup and improve performance by executing various modules of whois lookup to run concurrently by @yogeshojha in https://github.com/yogeshojha/rengine/pull/1368
 * chores: Add error handling for the curl command by @gitworkflows in https://github.com/yogeshojha/rengine/pull/1367
 * Update Github Actions Workflows by @yogeshojha in https://github.com/yogeshojha/rengine/pull/1369
 * chores: Fix docker build on master by @yogeshojha in https://github.com/yogeshojha/rengine/pull/1373


### PR DESCRIPTION
I previously saw `CVE-2024-41661` in the changelog and thought it needed to be changed to `CVE-2023-50094`. I should have noticed that version 2.1.3 fixes GHSA-96q4-fj2m-jqf7/`CVE-2024-43381`, not GHSA-fx7f-f735-vgh4/`CVE-2023-50094`. This commit refers to GHSA-96q4-fj2m-jqf7 by the correct CVE, `CVE-2024-43381`. I also corrected a minor capitalization typo on line 17.